### PR TITLE
Add return value conversion for QCoroTask

### DIFF
--- a/qcoro/impl/taskpromise.h
+++ b/qcoro/impl/taskpromise.h
@@ -38,13 +38,7 @@ inline void TaskPromise<T>::return_value(const T &value) noexcept {
 template<typename T>
 template<typename U> requires QCoro::concepts::constructible_from<T, U>
 inline void TaskPromise<T>::return_value(U &&value) noexcept {
-    mValue = std::move(value);
-}
-
-template<typename T>
-template<typename U> requires QCoro::concepts::constructible_from<T, U>
-inline void TaskPromise<T>::return_value(const U &value) noexcept {
-    mValue = value;
+    mValue = T(std::move(value));
 }
 
 template<typename T>

--- a/qcoro/qcorotask.h
+++ b/qcoro/qcorotask.h
@@ -220,9 +220,6 @@ public:
     template<typename U> requires QCoro::concepts::constructible_from<T, U>
     void return_value(U &&value) noexcept;
 
-    template<typename U> requires QCoro::concepts::constructible_from<T, U>
-    void return_value(const U &value) noexcept;
-
     //! Retrieves the result of the coroutine.
     /*!
      *  \return the value co_returned by the finished coroutine. If the coroutine has

--- a/tests/qcorotask.cpp
+++ b/tests/qcorotask.cpp
@@ -395,6 +395,12 @@ private:
         QCOMPARE(result, QStringLiteral("42"));
     }
 
+    void testReturnValueImplicitConversion(QCoro::TestContext) {
+        const auto testcoro [[maybe_unused]] = []() -> QCoro::Task<int> {
+            co_return 42LL;
+        };
+    }
+
     QCoro::Task<> testMultipleAwaiters_coro(QCoro::TestContext) {
         auto task = timer(100ms);
 


### PR DESCRIPTION
```cpp
const auto testcoro [[maybe_unused]] = []() -> QCoro::Task<int> {
    co_return 42LL;
};
```

As mValue is std::variant<std::monostate, T, std::exception_ptr>, narrowing conversion will not happen without explicit conversion.

BTW `template<typename U> requires /*...*/ void return_value(U &&value) noexcept` The U&& is a *universal reference*, so the unnecessary `const U& value` reload is removed.