### PR TITLE
fix: disable language-extension-token warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if (MSVC)
     endif()
 else()
     # Only enable strict warnings in debug mode
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror -pedantic")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror -pedantic -Wno-language-extension-token")
 
     if (ANDROID)
         include(DetectAndroidNDKVersion)


### PR DESCRIPTION
This warning breaks downstream builds because of how QCoro sets the compiler flags. A better solution would be for QCoro to set compiler flags using the `target_compile_options()` function for unit testing targets.

Resolves #265 