### PR TITLE
Fix infinite recursion with debug builds on libstdc++

### DIFF
--- a/qcoro/impl/lazytask.h
+++ b/qcoro/impl/lazytask.h
@@ -51,7 +51,7 @@ inline auto LazyTask<T>::operator co_await() const noexcept {
         }
 
         auto await_resume() {
-            Q_ASSERT(this->mAwaitedCoroutine != nullptr);
+            Q_ASSERT(this->mAwaitedCoroutine);
             if constexpr (!std::is_void_v<T>) {
                 return std::move(this->mAwaitedCoroutine.promise().result());
             } else {

--- a/qcoro/impl/taskbase.h
+++ b/qcoro/impl/taskbase.h
@@ -64,7 +64,7 @@ inline auto TaskBase<T, TaskImpl, PromiseType>::operator co_await() const noexce
          * \return the result from the coroutine's promise, factically the
          * value co_returned by the coroutine. */
         auto await_resume() {
-            Q_ASSERT(this->mAwaitedCoroutine != nullptr);
+            Q_ASSERT(this->mAwaitedCoroutine);
             if constexpr (!std::is_void_v<T>) {
                 return std::move(this->mAwaitedCoroutine.promise().result());
             } else {


### PR DESCRIPTION
On GCC 14.2.1 and libstdc++, during await_resume this comparison in taskbase.h:
```cpp
Q_ASSERT(this->mAwaitedCoroutine != nullptr);
```

seems to hit an infinite recursion in std::expected [here](https://github.com/gcc-mirror/gcc/blob/04696df09633baf97cdbbdd6e9929b9d472161d3/libstdc%2B%2B-v3/include/std/expected#L1131-L1135):
```cpp
template<typename _Up>
  friend constexpr bool
  operator==(const expected& __x, const _Up& __v)
  // FIXME: noexcept(noexcept(bool(*__x == __v)))
  { return __x.has_value() && bool(*__x == __v); }
```

for this template instance:
```cpp
std::operator==<std::coroutine_handle<QCoro::detail::TaskPromise<std::expected<A, B>>>>
```

where A and B are types used in my code.

I am not sure where the left-hand std::expected comes from, but it seems like the multiple implicit conversions that need to happen here (coroutine_handle<TaskPromise> to coroutine_handle<>, nullptr_t to coroutine_handle<>) cause sufficient ambiguity for GCC to perform the comparison in an unexpected way.

This is fixed if I change this to an implicit conversion to bool instead, as is done elsewhere in this file.