### PR TITLE
Don't leak compile definitions from interface libraries

### DIFF
--- a/cmake/AddQCoroLibrary.cmake
+++ b/cmake/AddQCoroLibrary.cmake
@@ -12,11 +12,7 @@ function(set_target_defaults target_name)
 
     get_target_property(target_type ${target_name} TYPE)
     if (target_type STREQUAL "INTERFACE_LIBRARY")
-        target_compile_definitions(
-            ${target_name}
-            INTERFACE
-            ${DEFAULT_QT_DEFINITIONS}
-        )
+        # We can't set compile definitions for interface libraries as that would leak into user code
         return()
     endif()
 


### PR DESCRIPTION
Interface (header-only) libraries cannot use compile-definitions since those affect the user code including them, which is not desired.

Fixes #274