### PR TITLE
Export nested awaiter classes from shared libraries

### DIFF
--- a/qcoro/core/qcoroiodevice.h
+++ b/qcoro/core/qcoroiodevice.h
@@ -20,7 +20,7 @@ namespace QCoro::detail {
 
 class QCOROCORE_EXPORT QCoroIODevice {
 private:
-    class OperationBase {
+    class QCOROCORE_EXPORT OperationBase {
     public:
         Q_DISABLE_COPY(OperationBase)
         QCORO_DEFAULT_MOVE(OperationBase)
@@ -39,7 +39,7 @@ private:
     };
 
 protected:
-    class ReadOperation : public OperationBase {
+    class QCOROCORE_EXPORT ReadOperation : public OperationBase {
     public:
         ReadOperation(QIODevice *device, std::function<QByteArray(QIODevice *)> &&resultCb);
         Q_DISABLE_COPY(ReadOperation)
@@ -53,7 +53,7 @@ protected:
         std::function<QByteArray(QIODevice *)> mResultCb;
     };
 
-    class ReadAllOperation final : public ReadOperation {
+    class QCOROCORE_EXPORT ReadAllOperation final : public ReadOperation {
     public:
         explicit ReadAllOperation(QIODevice *device);
         explicit ReadAllOperation(QIODevice &device);

--- a/qcoro/core/qcorothread.h
+++ b/qcoro/core/qcorothread.h
@@ -21,7 +21,7 @@ namespace detail {
 class ThreadContextPrivate;
 } // namespace detail
 
-class ThreadContext {
+class QCOROCORE_EXPORT ThreadContext {
 public:
     explicit ThreadContext(QThread *thread);
     ~ThreadContext();
@@ -44,7 +44,7 @@ private:
     std::unique_ptr<detail::ThreadContextPrivate> d;
 };
 
-ThreadContext moveToThread(QThread *thread);
+QCOROCORE_EXPORT ThreadContext moveToThread(QThread *thread);
 
 } // namespace QCoro
 

--- a/qcoro/core/qcorotimer.h
+++ b/qcoro/core/qcorotimer.h
@@ -17,7 +17,7 @@ namespace QCoro::detail {
 
 class QCOROCORE_EXPORT QCoroTimer {
 private:
-    class WaitForTimeoutOperation {
+    class QCOROCORE_EXPORT WaitForTimeoutOperation {
     public:
         explicit WaitForTimeoutOperation(QTimer *timer);
         explicit WaitForTimeoutOperation(QTimer &timer);

--- a/qcoro/dbus/qcorodbuspendingcall.h
+++ b/qcoro/dbus/qcorodbuspendingcall.h
@@ -18,7 +18,7 @@ namespace QCoro::detail {
 
 class QCORODBUS_EXPORT QCoroDBusPendingCall {
 private:
-    class WaitForFinishedOperation {
+    class QCORODBUS_EXPORT WaitForFinishedOperation {
     public:
         explicit WaitForFinishedOperation(const QDBusPendingCall &call);
 

--- a/qcoro/network/qcoronetworkreply.h
+++ b/qcoro/network/qcoronetworkreply.h
@@ -13,7 +13,7 @@ namespace QCoro::detail {
 
 class QCORONETWORK_EXPORT QCoroNetworkReply final : public QCoroIODevice {
 private:
-    class WaitForFinishedOperation final {
+    class QCORONETWORK_EXPORT WaitForFinishedOperation final {
     public:
         explicit WaitForFinishedOperation(QPointer<QNetworkReply> reply);
         ~WaitForFinishedOperation();

--- a/qcoro/network/qcorotcpserver.h
+++ b/qcoro/network/qcorotcpserver.h
@@ -22,7 +22,7 @@ using namespace std::chrono_literals;
 //! QTcpServer wrapper with co_awaitable-friendly API.
 class QCORONETWORK_EXPORT QCoroTcpServer {
     //! An Awaitable that suspends the coroutine until new connection is available
-    class WaitForNewConnectionOperation final : public WaitOperationBase<QTcpServer> {
+    class QCORONETWORK_EXPORT WaitForNewConnectionOperation final : public WaitOperationBase<QTcpServer> {
     public:
         WaitForNewConnectionOperation(QTcpServer *server, int timeout_msecs = 30'000);
         bool await_ready() const noexcept;

--- a/qcoro/qml/qcoroqmltask.h
+++ b/qcoro/qml/qcoroqmltask.h
@@ -98,7 +98,7 @@ private:
     QSharedDataPointer<QmlTaskPrivate> d;
 };
 
-class QmlTaskListener : public QObject {
+class QCOROQML_EXPORT QmlTaskListener : public QObject {
     Q_OBJECT
     QML_ANONYMOUS
     Q_PROPERTY(QVariant value READ value NOTIFY valueChanged)


### PR DESCRIPTION
On Windows shared builds, especially MinGW/MSYS2, once any symbol is marked `__declspec(dllexport)` GNU ld exports only those marked symbols. Nested awaiter types used by `co_await` in user code (for example `co_await nam.get(...)`) had out-of-line methods in the `.cpp` but no module export macro, so linking failed with undefined references to their constructors and destructors.

Linux is unaffected (no hidden visibility). The default Windows CI is also unaffected because it builds static libraries.

This adds the corresponding `QCORO*_EXPORT` macros to nested awaiters and other public types with out-of-line methods:

- `QCoroNetworkReply::WaitForFinishedOperation` (the reported `QNetworkReply*` awaiter)
- `QCoroTimer::WaitForTimeoutOperation`
- `QCoroIODevice::{OperationBase,ReadOperation,ReadAllOperation}`
- `QCoroDBusPendingCall::WaitForFinishedOperation`
- `QCoroTcpServer::WaitForNewConnectionOperation`
- `QCoro::ThreadContext` / `QCoro::moveToThread()`
- `QCoro::QmlTaskListener`

Fixes #346
Fixes #347
Fixes #348